### PR TITLE
CDI-90 -- Add name and shortname fields to Relationship.ConcreteValue.Type

### DIFF
--- a/src/main/java/org/snomed/otf/owltoolkit/domain/Relationship.java
+++ b/src/main/java/org/snomed/otf/owltoolkit/domain/Relationship.java
@@ -148,21 +148,14 @@ public class Relationship {
 	public static final class ConcreteValue {
 
 		public enum Type {
-			INTEGER("INTEGER", "int"),
-			DECIMAL("DECIMAL", "dec"),
-			STRING("STRING", "str");
+			INTEGER("int"),
+			DECIMAL("dec"),
+			STRING("str");
 
-			private final String name;
 			private final String shorthand;
 
-			Type(final String name,
-				 final String shorthand) {
-				this.name = name;
+			Type(String shorthand) {
 				this.shorthand = shorthand;
-			}
-
-			public String getName() {
-				return this.name;
 			}
 
 			public String getShorthand() {

--- a/src/main/java/org/snomed/otf/owltoolkit/domain/Relationship.java
+++ b/src/main/java/org/snomed/otf/owltoolkit/domain/Relationship.java
@@ -148,9 +148,26 @@ public class Relationship {
 	public static final class ConcreteValue {
 
 		public enum Type {
-			INTEGER,
-			DECIMAL,
-			STRING;
+			INTEGER("INTEGER", "int"),
+			DECIMAL("DECIMAL", "dec"),
+			STRING("STRING", "str");
+
+			private final String name;
+			private final String shorthand;
+
+			Type(final String name,
+				 final String shorthand) {
+				this.name = name;
+				this.shorthand = shorthand;
+			}
+
+			public String getName() {
+				return this.name;
+			}
+
+			public String getShorthand() {
+				return this.shorthand;
+			}
 		}
 
 		private final Type type;


### PR DESCRIPTION
CDI-90 is concerned with extracting the data type of a concrete value from both the snomed-owl-toolkit and the MRCM. 

To help with this, I have added two fields to Relationship.ConcreteValue.Type: these fields are later used in Snowstorm (ConcreteValue.DataType:from). 

Note: This code is related to snowstorm@feature/CDI-90.