### PR TITLE
Remove or suppress all log4j dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,12 @@
 			<groupId>org.semanticweb.elk</groupId>
 			<artifactId>elk-owlapi</artifactId>
 			<version>${elk-owlapi.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- Logging -->
@@ -60,7 +66,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.12</version>
+			<version>1.7.35</version>
 			<scope>provided</scope>
 		</dependency>
 


### PR DESCRIPTION
This is to mitigate vulnerability scanners flagging the snomed-owl-toolkit.jar as vulnerable.

Before the fix the following dependencies were pulled in:
- org.semanticweb.elk:elk-owlapi:jar:0.4.3 -> log4j:log4j:jar:1.2.14
- org.slf4j:slf4j-log4j12:jar:1.7.12 -> log4j:log4j:jar:1.2.17

After the fix no log4j dependencies are present in the resulting toolkit jar.

Tested the build to my limited capabilities. Everything looked OK, no missing log messages were observed.

A quick review and release would be much appreciated 🙏🏻 . Summoning @kaicode 