### PR TITLE
Fixes #61 Upgrade to latest minor version OWL-API.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<owlapi.version>4.1.3</owlapi.version>
+		<owlapi.version>4.5.21</owlapi.version>
 		<elk-owlapi.version>0.4.3</elk-owlapi.version>
 		<slf4j.version>1.7.25</slf4j.version>
 		<snomed.boot.version>3.0.0</snomed.boot.version>

--- a/src/main/java/org/snomed/otf/owltoolkit/ontology/render/SnomedPrefixManager.java
+++ b/src/main/java/org/snomed/otf/owltoolkit/ontology/render/SnomedPrefixManager.java
@@ -18,4 +18,9 @@ public class SnomedPrefixManager extends DefaultPrefixManager {
 		}
 		return null;
 	}
+
+	@Override
+	public String getPrefixIRIIgnoreQName(IRI iri) {
+		return getPrefixIRI(iri);
+	}
 }


### PR DESCRIPTION
Upgrade to latest minor version of the OWL API to avoid old version of the Google Guice library that causes JVM warnings in Java 8 and later (also affects Snowstorm).
All unit tests pass. One new namespace handler method was needed for the new library but that just delegates to existing code.
Classification of the Jan 2022 International release works as expected as does OWL file conversion. 